### PR TITLE
fix(travis): add greenkeeper lockfile support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ node_js:
   - node # uses most recent stable node version
 dist: trusty # uses trusty environment
 sudo: false # when on trusty, uses Docker containers for speed
+before_install:
+  - npm install -g greenkeeper-lockfile # needed to keep package-lock in sync
 install:
-  - npm i -g npm@5.7.1 # delete once 5.7.X is out of "pre-release"
-  - npm ci             # faster, goes only from package-lock
+  - case $TRAVIS_BRANCH in greenkeeper*) npm i;; *) npm ci;; esac; # use `npm i` on greenkeeper branches
+before_script:
+  - greenkeeper-lockfile-update
+after_script:
+  - greenkeeper-lockfile-upload


### PR DESCRIPTION
### Assignee Tasks

Please check all that apply.

*   [x] referenced any relevant issue(s)
*   [ ] Adding new rule(s)?
    *   [ ] Included rule summary verbatim from docs as a comment
    *   [ ] Placed in the right section (stylistic / node / etc.), in alphabetical order
    *   [ ] Set to `0` (off), `1` (warn), or `2` (error) as spec'd in contributing guidelines
*   [ ] Changing active rule(s) severity?
    *   [ ] Set to `1` (warn), or `2` (error) as spec'd in contributing guidelines
*   [ ] Removing rule(s)?
    *   [ ] Set to `0` if disabling, or delete _only if deprecated_

---

If `package-lock.json` and `package.json` disagree, `npm ci` errors out. This messes with Greenkeeper. This PR aims to fix the issue by integrating with [greenkeeper-lockfile](https://github.com/greenkeeperio/greenkeeper-lockfile).