### PR TITLE
fix(travis): npm ci -> npm i

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false # when on trusty, uses Docker containers for speed
 before_install:
   - npm install -g greenkeeper-lockfile # needed to keep package-lock in sync
 install:
-  - case $TRAVIS_BRANCH in greenkeeper*) npm i;; *) npm ci;; esac; # use `npm i` on greenkeeper branches
+  - npm i # disable npm ci for greenkeeper's sake
 before_script:
   - greenkeeper-lockfile-update
 after_script:


### PR DESCRIPTION
### Assignee Tasks

Please check all that apply.

*   [x] referenced any relevant issue(s)
*   [ ] Adding new rule(s)?
    *   [ ] Included rule summary verbatim from docs as a comment
    *   [ ] Placed in the right section (stylistic / node / etc.), in alphabetical order
    *   [ ] Set to `0` (off), `1` (warn), or `2` (error) as spec'd in contributing guidelines
*   [ ] Changing active rule(s) severity?
    *   [ ] Set to `1` (warn), or `2` (error) as spec'd in contributing guidelines
*   [ ] Removing rule(s)?
    *   [ ] Set to `0` if disabling, or delete _only if deprecated_

---

Command to auto-select between `npm i` and `npm ci` for greenkeeper branches failed. Falling back to only using `npm i`.